### PR TITLE
Use commonform-resolve@0.7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ assert.deepEqual(
               { form: { content: [ 'D' ] } },
               { form: { content: [ 'E' ] } },
               'after' ] } },
-        'after' ] },
+        'after',
+        { use: 'A Defined Term'} ] },
     { company: 'NewCo' }),
   [ { depth: 1,
-      content: [ 'some text NewCo' ] },
+      content: [
+        'some text ',
+        { blank: 'company', value: 'NewCo' } ] },
     { depth: 2,
       heading: 'A',
       content: [ 'before' ],
@@ -66,5 +69,7 @@ assert.deepEqual(
       content: [ 'after' ],
       conspicuous: 'yes' },
     { depth: 1,
-      content: [ 'after' ] } ])
+      content: [
+        'after',
+        { use: 'A Defined Term' } ] } ])
 ```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (http://kemitchell.com)",
   "bugs": "https://github.com/commonform/commonform-flatten/issues",
   "dependencies": {
-    "commonform-resolve": "0.6.x"
+    "commonform-resolve": "0.7.x"
   },
   "devDependencies": {
     "defence-cli": "^1.0.1",


### PR DESCRIPTION
Updating to use new commonform-resolve, which passes term uses and blanks through as objects.

A SemVer breaking change.

cc: @anseljh
